### PR TITLE
FM2-549: Adding MedicationDispense to index.md

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -20,10 +20,11 @@ the FHIR module supports the export of the following FHIR Resources
 8. [DiagnosticReport](https://fhir.openmrs.org/StructureDefinition-OpenMRS-diagnostic-report.html)
 9. [Encounter](https://fhir.openmrs.org/StructureDefinition-omrs-encounter.html)
 10. [MedicationRequest](https://fhir.openmrs.org/StructureDefinition-omrs-medication-request.html)
-11. [ServiceRequest](https://fhir.openmrs.org/StructureDefinition-OpenMRS-service-request.html)
-12. [Task](https://fhir.openmrs.org/StructureDefinition-OpenMRS-task.html)
-13. [Group](https://fhir.openmrs.org/StructureDefinition-omrs-group.html)
-14. [Immunization](https://fhir.openmrs.org/StructureDefinition-omrs-immunization.html)
+11. [MedicationDispense](https://fhir.openmrs.org/StructureDefinition-omrsmedication-dispense.html)
+12. [ServiceRequest](https://fhir.openmrs.org/StructureDefinition-OpenMRS-service-request.html)
+13. [Task](https://fhir.openmrs.org/StructureDefinition-OpenMRS-task.html)
+14. [Group](https://fhir.openmrs.org/StructureDefinition-omrs-group.html)
+15. [Immunization](https://fhir.openmrs.org/StructureDefinition-omrs-immunization.html)
 
 ### About This Implementation Guide <a name="about"/>
 The top menu allows quick navigation to the different sections, and a Table of Contents is provided with the entire content of this Implementation Guide.


### PR DESCRIPTION
Follow up commit to https://issues.openmrs.org/browse/FM2-549 to add `MedicationDispense` to the landing page so as to make navigation easy.

cc: @abertnamanya @sherrif10 